### PR TITLE
Add initial Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM docker.io/rakudo-star:latest
+
+RUN apt-get update -y && \
+    apt-get install -y build-essential && \
+    apt-get purge -y
+
+RUN mkdir /src
+COPY . /src
+WORKDIR /src
+RUN zef install --/test --deps-only .
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,21 @@
 FROM docker.io/rakudo-star:latest
 
+# Install make, gcc, etc.
 RUN apt-get update -y && \
     apt-get install -y build-essential && \
     apt-get purge -y
 
-RUN mkdir /src
-COPY . /src
-WORKDIR /src
+# Copy in Raku source code and build
+RUN mkdir -p /opt/rakuast-rakudoc-render
+COPY . /opt/rakuast-rakudoc-render
+WORKDIR /opt/rakuast-rakudoc-render
 RUN zef install --/test --deps-only .
+
+# symlink executable to location on PATH
+RUN ln -s /opt/rakuast-rakudoc-render/bin/RenderDocs /usr/local/bin/RenderDocs
+
+
+# Make a new WORKDIR where users will mount their code
+RUN mkdir /src
+WORKDIR /src
 


### PR DESCRIPTION
This is a simple take on a docker build that uses the rakudo base container.

Test from the root of the directory like this

    docker build -t localhost/rakuast-rakudoc-render:latest .

The `podman` executable can be used instead of `docker`, as well.

Details on usage are TBD, but it will involve users mounting their source code inside as a volume mount.