### PR TITLE
List files sort order

### DIFF
--- a/docs/plugins/ListFiles.rakudoc
+++ b/docs/plugins/ListFiles.rakudoc
@@ -48,6 +48,26 @@ Descriptions of the Renderer classes
 File from other sources or automatically generated
 =end code
 
+By default, matching files are listed alphabetically by title.
+To control the order, add C<:sort-byE<lt>fieldE<gt>> to the
+C<ListFiles> block. Any metadata field can be used for ordering, eg.
+
+=begin code :lang<RakuDoc>
+    =begin rakudoc :type<plugin> :nav-order<20>
+    =TITLE Grouping files in an index
+    =SUBTITLE The plugin takes data collected from other files
+    ...
+    =end rakudoc
+
+    =for ListFiles :select<type=plugin> :sort-by<nav-order>
+=end code
+
+If the chosen sort field contains integers, the entries are
+sorted numerically. When the field is missing or empty, that
+entry falls back to sorting by title. The values C<title>,
+C<subtitle>, and C<route> can also be used with C<:sort-by>,
+as can custom metadata such as C<nav-order>.
+
 The last example shows how to capture files that do not have a
 type option. A file not matching any of the select criteria are
 not listed, so having a catchall syntax ensures all the

--- a/lib/RakuDoc/Plugin/HTML/ListFiles.rakumod
+++ b/lib/RakuDoc/Plugin/HTML/ListFiles.rakumod
@@ -16,6 +16,27 @@ method enable( RakuDoc::Processor:D $rdp ) {
     $rdp.add-templates( $.templates, :source<ListFiles plugin> );
     $rdp.add-data( %!config<name-space>, %!config );
 }
+method !file-title(%data, $fn) {
+    (%data<title> eq '' or %data<title> eq 'NO_TITLE') ?? $fn !! %data<title>
+}
+method !sort-key(%data, $fn, $sort-by --> Str) {
+    my $title = self!file-title(%data, $fn);
+    my $title-key = $title.lc;
+    $sort-by.chars or return "1|$title-key|$title-key";
+
+    my $raw = do given $sort-by {
+        when 'title' { $title }
+        when 'subtitle' | 'route' { %data{$sort-by} // '' }
+        default { %data<config>{$sort-by} // '' }
+    }
+    ;
+    my $sort-value = $raw.Str.trim;
+    $sort-value eq '' and return "1|$title-key|$title-key";
+
+    $sort-value ~~ /^ '-'? \d+ $/
+        ?? "0|{sprintf('%020d', $sort-value.Int)}|$title-key"
+        !! "1|{$sort-value.lc}|$title-key"
+}
 method templates {
     my regex s-pair {
         (<-[=]>+) \= (.+?)
@@ -66,8 +87,10 @@ method templates {
                     last unless $ok
                 }
                 next unless $ok;
+                my $title = self!file-title(%data, $fn);
                 @sel-files.push: [
-                    ((%data<title> eq '' or %data<title> eq 'NO_TITLE') ?? $fn !! %data<title> ),
+                    self!sort-key(%data, $fn, %prm<sort-by>:exists ?? %prm<sort-by>.Str !! ''),
+                    $title,
                     (%data<subtitle> ?? %data<subtitle> !! 'No description found'),
                     %data<route> // $fn
                 ];
@@ -78,7 +101,7 @@ method templates {
             my $cap = qq:to/CAP/;
                     <p class="listf-caption">{ %prm<raw>.trim }</p>
                     CAP
-            for  @sel-files.sort(*.[0]) -> ($nm, $desc, $route) {
+            for  @sel-files.sort(*.[0]) -> ($sort, $nm, $desc, $route) {
                 $rv ~= qq:to/NOFL/;
                     <div class="listf-file">
                     $cap

--- a/xt/215-H-E-Plugin-ListFiles.rakutest
+++ b/xt/215-H-E-Plugin-ListFiles.rakutest
@@ -3,7 +3,7 @@ use Test;
 
 use RakuDoc::To::HTML;
 
-plan 7;
+plan 11;
 
 my $html-instance = RakuDoc::To::HTML.new;
 my $rdp := $html-instance.rdp;
@@ -15,6 +15,10 @@ lives-ok {
 isa-ok %d<listfiles>, Associative, 'ListFiles plugin config available';
 my %lf := %d<listfiles>;
 %lf<meta> = EVALFILE 'xt/test-files/file-data.rakuon';
+%lf<meta><Language/operators><config><nav-order> = 20;
+%lf<meta><Language/101-basics><config><nav-order> = 5;
+%lf<meta><Language/operators><config><nav-label> = '20L';
+%lf<meta><Language/101-basics><config><nav-label> = '5L';
 my $temp-out;
 lives-ok { $temp-out = $rdp.templates<ListFiles>( %(
     :raw("Getting started\n\n"),
@@ -28,5 +32,25 @@ like $temp-out, /
 like $temp-out, / 'Language/operators' /, 'got link';
 like $temp-out, / 'Operators' /, 'got title';
 like $temp-out, / 'Common Raku infixes, prefixes' /, 'got subtitle';
+
+my $numeric-sorted-out;
+lives-ok { $numeric-sorted-out = $rdp.templates<ListFiles>( %(
+    :select('kind=Language'),
+    :sort-by('nav-order')
+    )
+    )},
+    'template sorts numerically on configured metadata';
+ok $numeric-sorted-out.index('Raku by example 101') < $numeric-sorted-out.index('Operators'),
+    '5 sorts before 20 numerically';
+
+my $string-sorted-out;
+lives-ok { $string-sorted-out = $rdp.templates<ListFiles>( %(
+    :select('kind=Language'),
+    :sort-by('nav-label')
+    )
+    )},
+    'template sorts lexically on configured metadata';
+ok $string-sorted-out.index('Operators') < $string-sorted-out.index('Raku by example 101'),
+    '20L sorts before 5L lexically';
 
 done-testing;


### PR DESCRIPTION
Provides a way that files can be ordered in a ListFiles.  

# Summary
In the source file:
```
=begin pod :page-card<CrewsCompiler> :nav-order<10>
```

In the index/glue file:
```
=begin ListFiles :select<page-card=CrewsCompiler> :sort-by<nav-order>
Compiler Crews
=end ListFiles
```